### PR TITLE
Fix layout issue when users do not have titles

### DIFF
--- a/src/components/ChatterOrgChartSingleUserComponent.component
+++ b/src/components/ChatterOrgChartSingleUserComponent.component
@@ -1,17 +1,17 @@
 <apex:component >
-    
+
     <apex:attribute name="user" description="The user profile card to display"
                     type="User" required="true"/>
-    
+
     <apex:attribute name="highlight" description="Apply styling to emphasize this user profile card"
                     type="Boolean" required="false" default="false"/>
-    
+
     <div class="list-group">
         <a href="/_ui/core/userprofile/UserProfilePage?u={!user.id}&tab=Chatter_Org_Chart" target="_top" class="list-group-item {!IF(highlight, 'list-group-item-info', '')}">
             <img src="{!user.smallPhotoURL}" class="img-circle" width="64px" height="64px"/>
             <p class="user-name"><apex:outputText value="{!user.name}"/></p>
-            <p class="user-title"><apex:outputText value="{!user.title}"/></p>
+            <p class="user-title">&nbsp;<apex:outputText value="{!user.title}"/>&nbsp;</p>
         </a>
     </div>
-    
+
 </apex:component>


### PR DESCRIPTION
If any user in the heirarchy does not have a title, user profile card is not tall enough, thus breaking the floats for other records.